### PR TITLE
Update user.css - fixed Shuffle and Repeat buttons

### DIFF
--- a/user.css
+++ b/user.css
@@ -31,7 +31,9 @@
 .__color, .HbKLiGoYM4dpuK8L4TMX, .connect-device-list-item--active,
 .connect-device-list-item--active *,
 .control-button--active,
-.main-repeatButton-button {
+.main-repeatButton-button[aria-checked="true"],
+.main-repeatButton-button[aria-checked="mixed"],
+.main-shuffleButton-button[aria-checked="true"] {
   color: var(--spice-color) !important;
   fill: var(--spice-color) !important;
 }


### PR DESCRIPTION
Added a CSS attribute selection for color alteration of only enabled buttons.
Reason was the exclusion of the shuffle button from the original .css and the constant confusion between repeat having aria-checked="false" and aria-checked="true" having only a small dot as a difference on the client.