### PR TITLE
Removed playlist Play color broken by Spotify

### DIFF
--- a/user.css
+++ b/user.css
@@ -19,7 +19,7 @@
   --lyrics-color-messaging: #333333 !important;
 }
 
-.__background, .main-playButton-PlayButton,
+.__background,
 .main-playButton-primary,
 .ButtonInner-sc-14ud5tc-0,
 .main-button-primary,


### PR DESCRIPTION
Spotify changed their CSS in a recent update, and as a result caused the entire area of the class element being colored whilst viewing a playlist.

I've isolated the class which was changed and removed it from the .css

Lazy before and after:
![image](https://user-images.githubusercontent.com/94653983/186390926-559e80c2-3ec4-48ee-9804-9aacbb927867.png)
