### PR TITLE
fix: color of equaliser gif and playlist's playpause button;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+color.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-color.ini

--- a/user.css
+++ b/user.css
@@ -131,3 +131,12 @@ button[aria-label="Playing"],
   padding-bottom: 0 !important;
   margin-bottom: 12px !important;
 }
+
+.e-9640-button-primary:hover .e-9640-button-primary__inner {
+  background-color: var(--spice-color) !important;
+  filter: brightness(1.2) !important;
+}
+
+.view-homeShortcutsGrid-equaliser {
+  filter: brightness(1000%) !important;
+}


### PR DESCRIPTION
Equaliser gif and playlist's playpause button where still using default color instead of the accent color or one matching the theme.